### PR TITLE
Update languages.txt

### DIFF
--- a/frappe/data/languages.txt
+++ b/frappe/data/languages.txt
@@ -33,5 +33,5 @@ ta	தமிழ்
 th	ไทย
 tr	Türk
 vi	việt
-zh-cn	中国（简体）
-zh-tw	中國（繁體）
+zh-cn	中文（简体）
+zh-tw	中文（繁體）


### PR DESCRIPTION
Fix the language name in both Simplified Chinese and Traditional Chinese.  "中國" or "中国" is country name, "中文" is the language.
